### PR TITLE
Bugfix: centos 7 packages require the LOGINTERVAL env variable, not t…

### DIFF
--- a/templates/atop-RedHat.erb
+++ b/templates/atop-RedHat.erb
@@ -13,3 +13,4 @@ BINPATH=/usr/bin
 PIDFILE=/var/run/atop.pid
 # interval (default 10 minutes)
 INTERVAL=<%= @interval %>
+LOGINTERVAL=<%= @interval %>


### PR DESCRIPTION
…he INTERVAL one